### PR TITLE
Rebuild for libboost 1.82

### DIFF
--- a/.ci_support/linux_64_llvm11llvmdev11.yaml
+++ b/.ci_support/linux_64_llvm11llvmdev11.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '11'
 llvmdev:
 - '11'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_64_llvm12llvmdev12.yaml
+++ b/.ci_support/linux_64_llvm12llvmdev12.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '12'
 llvmdev:
 - '12'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_64_llvm13llvmdev13.yaml
+++ b/.ci_support/linux_64_llvm13llvmdev13.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '13'
 llvmdev:
 - '13'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_64_llvm14llvmdev14.yaml
+++ b/.ci_support/linux_64_llvm14llvmdev14.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '14'
 llvmdev:
 - '14'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_64_llvm15llvmdev15.yaml
+++ b/.ci_support/linux_64_llvm15llvmdev15.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '15'
 llvmdev:
 - '15'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_64_llvm16llvmdev16.yaml
+++ b/.ci_support/linux_64_llvm16llvmdev16.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '16'
 llvmdev:
 - '16'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_aarch64_llvm11llvmdev11.yaml
+++ b/.ci_support/linux_aarch64_llvm11llvmdev11.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -24,15 +22,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '11'
 llvmdev:
 - '11'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_aarch64_llvm12llvmdev12.yaml
+++ b/.ci_support/linux_aarch64_llvm12llvmdev12.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -24,15 +22,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '12'
 llvmdev:
 - '12'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_aarch64_llvm13llvmdev13.yaml
+++ b/.ci_support/linux_aarch64_llvm13llvmdev13.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -24,15 +22,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '13'
 llvmdev:
 - '13'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_aarch64_llvm14llvmdev14.yaml
+++ b/.ci_support/linux_aarch64_llvm14llvmdev14.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -24,15 +22,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '14'
 llvmdev:
 - '14'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_aarch64_llvm15llvmdev15.yaml
+++ b/.ci_support/linux_aarch64_llvm15llvmdev15.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -24,15 +22,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '15'
 llvmdev:
 - '15'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_aarch64_llvm16llvmdev16.yaml
+++ b/.ci_support/linux_aarch64_llvm16llvmdev16.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -24,15 +22,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '16'
 llvmdev:
 - '16'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_ppc64le_llvm11llvmdev11.yaml
+++ b/.ci_support/linux_ppc64le_llvm11llvmdev11.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '11'
 llvmdev:
 - '11'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_ppc64le_llvm12llvmdev12.yaml
+++ b/.ci_support/linux_ppc64le_llvm12llvmdev12.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '12'
 llvmdev:
 - '12'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_ppc64le_llvm13llvmdev13.yaml
+++ b/.ci_support/linux_ppc64le_llvm13llvmdev13.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '13'
 llvmdev:
 - '13'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_ppc64le_llvm14llvmdev14.yaml
+++ b/.ci_support/linux_ppc64le_llvm14llvmdev14.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '14'
 llvmdev:
 - '14'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_ppc64le_llvm15llvmdev15.yaml
+++ b/.ci_support/linux_ppc64le_llvm15llvmdev15.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '15'
 llvmdev:
 - '15'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/linux_ppc64le_llvm16llvmdev16.yaml
+++ b/.ci_support/linux_ppc64le_llvm16llvmdev16.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,15 +18,14 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '16'
 llvmdev:
 - '16'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/migrations/boost_cpp_to_libboost.yaml
+++ b/.ci_support/migrations/boost_cpp_to_libboost.yaml
@@ -1,0 +1,20 @@
+migrator_ts: 1695775149
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: "Rebuild for libboost 1.82"
+  # limit the number of prs for ramp-up
+  pr_limit: 10
+libboost_devel:
+  - 1.82
+# This migration is matched with a piggy-back migrator
+# (see https://github.com/regro/cf-scripts/pull/1668)
+# that will replace boost-cpp with libboost-devel
+boost_cpp:
+  - 1.82
+# same for boost -> libboost-python-devel
+libboost_python_devel:
+  - 1.82
+boost:
+  - 1.82

--- a/.ci_support/osx_64_llvm11llvmdev11.yaml
+++ b/.ci_support/osx_64_llvm11llvmdev11.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MACOSX_SDK_VERSION:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -20,6 +18,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '11'
 llvmdev:
@@ -28,9 +28,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_64_llvm12llvmdev12.yaml
+++ b/.ci_support/osx_64_llvm12llvmdev12.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MACOSX_SDK_VERSION:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -20,6 +18,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '12'
 llvmdev:
@@ -28,9 +28,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_64_llvm13llvmdev13.yaml
+++ b/.ci_support/osx_64_llvm13llvmdev13.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MACOSX_SDK_VERSION:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -20,6 +18,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '13'
 llvmdev:
@@ -28,9 +28,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_64_llvm14llvmdev14.yaml
+++ b/.ci_support/osx_64_llvm14llvmdev14.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MACOSX_SDK_VERSION:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -20,6 +18,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '14'
 llvmdev:
@@ -28,9 +28,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_64_llvm15llvmdev15.yaml
+++ b/.ci_support/osx_64_llvm15llvmdev15.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MACOSX_SDK_VERSION:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -20,6 +18,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '15'
 llvmdev:
@@ -28,9 +28,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_64_llvm16llvmdev16.yaml
+++ b/.ci_support/osx_64_llvm16llvmdev16.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MACOSX_SDK_VERSION:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -20,6 +18,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '16'
 llvmdev:
@@ -28,9 +28,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_arm64_llvm11llvmdev11.yaml
+++ b/.ci_support/osx_arm64_llvm11llvmdev11.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +16,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '11'
 llvmdev:
@@ -26,9 +26,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_arm64_llvm12llvmdev12.yaml
+++ b/.ci_support/osx_arm64_llvm12llvmdev12.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +16,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '12'
 llvmdev:
@@ -26,9 +26,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_arm64_llvm13llvmdev13.yaml
+++ b/.ci_support/osx_arm64_llvm13llvmdev13.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +16,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '13'
 llvmdev:
@@ -26,9 +26,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_arm64_llvm14llvmdev14.yaml
+++ b/.ci_support/osx_arm64_llvm14llvmdev14.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +16,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '14'
 llvmdev:
@@ -26,9 +26,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_arm64_llvm15llvmdev15.yaml
+++ b/.ci_support/osx_arm64_llvm15llvmdev15.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +16,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '15'
 llvmdev:
@@ -26,9 +26,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/osx_arm64_llvm16llvmdev16.yaml
+++ b/.ci_support/osx_arm64_llvm16llvmdev16.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +16,8 @@ fmt:
 - '10'
 gmp:
 - '6'
+libboost_devel:
+- '1.82'
 llvm:
 - '16'
 llvmdev:
@@ -26,9 +26,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/win_64_llvm12llvmdev12.yaml
+++ b/.ci_support/win_64_llvm12llvmdev12.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - vs2019
 channel_sources:
@@ -10,15 +8,14 @@ cxx_compiler:
 - vs2019
 fmt:
 - '10'
+libboost_devel:
+- '1.82'
 llvm:
 - '12'
 llvmdev:
 - '12'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/win_64_llvm13llvmdev13.yaml
+++ b/.ci_support/win_64_llvm13llvmdev13.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - vs2019
 channel_sources:
@@ -10,15 +8,14 @@ cxx_compiler:
 - vs2019
 fmt:
 - '10'
+libboost_devel:
+- '1.82'
 llvm:
 - '13'
 llvmdev:
 - '13'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/win_64_llvm14llvmdev14.yaml
+++ b/.ci_support/win_64_llvm14llvmdev14.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - vs2019
 channel_sources:
@@ -10,15 +8,14 @@ cxx_compiler:
 - vs2019
 fmt:
 - '10'
+libboost_devel:
+- '1.82'
 llvm:
 - '14'
 llvmdev:
 - '14'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/win_64_llvm15llvmdev15.yaml
+++ b/.ci_support/win_64_llvm15llvmdev15.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - vs2019
 channel_sources:
@@ -10,15 +8,14 @@ cxx_compiler:
 - vs2019
 fmt:
 - '10'
+libboost_devel:
+- '1.82'
 llvm:
 - '15'
 llvmdev:
 - '15'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/.ci_support/win_64_llvm16llvmdev16.yaml
+++ b/.ci_support/win_64_llvm16llvmdev16.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - vs2019
 channel_sources:
@@ -10,15 +8,14 @@ cxx_compiler:
 - vs2019
 fmt:
 - '10'
+libboost_devel:
+- '1.82'
 llvm:
 - '16'
 llvmdev:
 - '16'
 mpfr:
 - '4'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 spdlog:
 - '1.12'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 418ce55557496d3ff1383e8b64663661d9b6a5f39dc7080e401d6537db0c4cd2
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports_from:
     # NOTE: on most platforms, except
     # PPC64, we are forcing static linking
@@ -39,7 +39,7 @@ outputs:
       host:
         - llvmdev
         - llvm
-        - boost-cpp
+        - libboost-devel
         # NOTE: this one is needed only
         # on some platforms and LLVM versions.
         # Just leave it everywhere even if
@@ -59,7 +59,6 @@ outputs:
         - mppp >=0.27
         - zlib          # [not ppc64le]
       run:
-        - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
     build:
       run_exports:
@@ -84,7 +83,7 @@ outputs:
       host:
         - llvmdev
         - llvm
-        - boost-cpp
+        - libboost-devel
         - zstd
         - fmt
         - spdlog
@@ -101,7 +100,6 @@ outputs:
         - zlib          # [not ppc64le]
         - {{ pin_subpackage('heyoka', exact=True) }}
       run:
-        - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
         - {{ pin_subpackage('heyoka', exact=True) }}
     build:


### PR DESCRIPTION
The dynamic name of one of the outputs here (`heyoka-llvm-{{ llvmdev }}`) makes it impossible to run the logic necessary for the boost rename bot, so we need to do it manually.