### PR TITLE
Rebuild for libboost 1.84 

### DIFF
--- a/.ci_support/linux_64_llvm13llvmdev13.yaml
+++ b/.ci_support/linux_64_llvm13llvmdev13.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '13'
 llvmdev:

--- a/.ci_support/linux_64_llvm14llvmdev14.yaml
+++ b/.ci_support/linux_64_llvm14llvmdev14.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '14'
 llvmdev:

--- a/.ci_support/linux_64_llvm15llvmdev15.yaml
+++ b/.ci_support/linux_64_llvm15llvmdev15.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '15'
 llvmdev:

--- a/.ci_support/linux_64_llvm16llvmdev16.yaml
+++ b/.ci_support/linux_64_llvm16llvmdev16.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '16'
 llvmdev:

--- a/.ci_support/linux_64_llvm17llvmdev17.yaml
+++ b/.ci_support/linux_64_llvm17llvmdev17.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '17'
 llvmdev:

--- a/.ci_support/linux_aarch64_llvm13llvmdev13.yaml
+++ b/.ci_support/linux_aarch64_llvm13llvmdev13.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '13'
 llvmdev:

--- a/.ci_support/linux_aarch64_llvm14llvmdev14.yaml
+++ b/.ci_support/linux_aarch64_llvm14llvmdev14.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '14'
 llvmdev:

--- a/.ci_support/linux_aarch64_llvm15llvmdev15.yaml
+++ b/.ci_support/linux_aarch64_llvm15llvmdev15.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '15'
 llvmdev:

--- a/.ci_support/linux_aarch64_llvm16llvmdev16.yaml
+++ b/.ci_support/linux_aarch64_llvm16llvmdev16.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '16'
 llvmdev:

--- a/.ci_support/linux_aarch64_llvm17llvmdev17.yaml
+++ b/.ci_support/linux_aarch64_llvm17llvmdev17.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '17'
 llvmdev:

--- a/.ci_support/linux_ppc64le_llvm13llvmdev13.yaml
+++ b/.ci_support/linux_ppc64le_llvm13llvmdev13.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '13'
 llvmdev:

--- a/.ci_support/linux_ppc64le_llvm14llvmdev14.yaml
+++ b/.ci_support/linux_ppc64le_llvm14llvmdev14.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '14'
 llvmdev:

--- a/.ci_support/linux_ppc64le_llvm15llvmdev15.yaml
+++ b/.ci_support/linux_ppc64le_llvm15llvmdev15.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '15'
 llvmdev:

--- a/.ci_support/linux_ppc64le_llvm16llvmdev16.yaml
+++ b/.ci_support/linux_ppc64le_llvm16llvmdev16.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '16'
 llvmdev:

--- a/.ci_support/linux_ppc64le_llvm17llvmdev17.yaml
+++ b/.ci_support/linux_ppc64le_llvm17llvmdev17.yaml
@@ -20,6 +20,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '17'
 llvmdev:

--- a/.ci_support/migrations/boost1840.yaml
+++ b/.ci_support/migrations/boost1840.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for libboost 1.84"
+  migration_number: 1
+libboost_devel:
+- "1.84"
+libboost_python_devel:
+- "1.84"
+migrator_ts: 1700834511.141209

--- a/.ci_support/osx_64_llvm13llvmdev13.yaml
+++ b/.ci_support/osx_64_llvm13llvmdev13.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '13'
 llvmdev:

--- a/.ci_support/osx_64_llvm14llvmdev14.yaml
+++ b/.ci_support/osx_64_llvm14llvmdev14.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '14'
 llvmdev:

--- a/.ci_support/osx_64_llvm15llvmdev15.yaml
+++ b/.ci_support/osx_64_llvm15llvmdev15.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '15'
 llvmdev:

--- a/.ci_support/osx_64_llvm16llvmdev16.yaml
+++ b/.ci_support/osx_64_llvm16llvmdev16.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '16'
 llvmdev:

--- a/.ci_support/osx_64_llvm17llvmdev17.yaml
+++ b/.ci_support/osx_64_llvm17llvmdev17.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '17'
 llvmdev:

--- a/.ci_support/osx_arm64_llvm13llvmdev13.yaml
+++ b/.ci_support/osx_arm64_llvm13llvmdev13.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '13'
 llvmdev:

--- a/.ci_support/osx_arm64_llvm14llvmdev14.yaml
+++ b/.ci_support/osx_arm64_llvm14llvmdev14.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '14'
 llvmdev:

--- a/.ci_support/osx_arm64_llvm15llvmdev15.yaml
+++ b/.ci_support/osx_arm64_llvm15llvmdev15.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '15'
 llvmdev:

--- a/.ci_support/osx_arm64_llvm16llvmdev16.yaml
+++ b/.ci_support/osx_arm64_llvm16llvmdev16.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '16'
 llvmdev:

--- a/.ci_support/osx_arm64_llvm17llvmdev17.yaml
+++ b/.ci_support/osx_arm64_llvm17llvmdev17.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '16'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
 llvm:
 - '17'
 llvmdev:

--- a/.ci_support/win_64_llvm13llvmdev13.yaml
+++ b/.ci_support/win_64_llvm13llvmdev13.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.84'
 llvm:
 - '13'
 llvmdev:

--- a/.ci_support/win_64_llvm14llvmdev14.yaml
+++ b/.ci_support/win_64_llvm14llvmdev14.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.84'
 llvm:
 - '14'
 llvmdev:

--- a/.ci_support/win_64_llvm15llvmdev15.yaml
+++ b/.ci_support/win_64_llvm15llvmdev15.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.84'
 llvm:
 - '15'
 llvmdev:

--- a/.ci_support/win_64_llvm16llvmdev16.yaml
+++ b/.ci_support/win_64_llvm16llvmdev16.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.84'
 llvm:
 - '16'
 llvmdev:

--- a/.ci_support/win_64_llvm17llvmdev17.yaml
+++ b/.ci_support/win_64_llvm17llvmdev17.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.84'
 llvm:
 - '17'
 llvmdev:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.18.0
     - make       # [unix]
@@ -58,8 +59,6 @@ outputs:
         - blas-devel    # [not osx]
         - mppp =1.*
         - zlib          # [not ppc64le]
-      run:
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
     build:
       run_exports:
         # SO name changes at minor rev bumps.
@@ -100,7 +99,6 @@ outputs:
         - zlib          # [not ppc64le]
         - {{ pin_subpackage('heyoka', exact=True) }}
       run:
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
         - {{ pin_subpackage('heyoka', exact=True) }}
     build:
       run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 47608e785607782d896ae2347a29a143cdb7e5c602f48f5ea795cf682051dbee
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports_from:
     # NOTE: on most platforms, except
     # PPC64, we are forcing static linking
@@ -39,7 +39,7 @@ outputs:
       host:
         - llvmdev
         - llvm
-        - libboost-devel >=1.69
+        - libboost-devel
         # NOTE: this one is needed only
         # on some platforms and LLVM versions.
         # Just leave it everywhere even if
@@ -83,7 +83,7 @@ outputs:
       host:
         - llvmdev
         - llvm
-        - libboost-devel >=1.69
+        - libboost-devel
         - zstd
         - fmt >=9,<11
         - spdlog


### PR DESCRIPTION
Migrator failed due to templated outputname; also use this opportunity to ensure that boost pins are picked up correctly.

PS. Despite removing
```
- __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
```
it's not necessary to change anything in CBC, because it doesn't actually set `MACOSX_DEPLOYMENT_TARGET`, only the SDK:
https://github.com/conda-forge/heyoka-feedstock/blob/d3efffa21c5b81f6e5e5029bc7c9de282ffa9880/recipe/conda_build_config.yaml#L16-L17